### PR TITLE
Fix PHP syntax error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -745,7 +745,7 @@ if (!class_exists('WPGraphQLGutenberg')) {
                                                     __(
                                                         'Failed to update reusable block meta field for wp_block %d.'
                                                     ),
-                                                    $post->ID,
+                                                    $post->ID
                                                 ),
                                                 array('status' => 500)
                                             );


### PR DESCRIPTION
This throws an arrow while running the Plugin on PHP7. Wordpress would simply throw a fatal error.