### PR TITLE
check for $attribute['type'] existence before using it

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -274,26 +274,28 @@ if (!class_exists('WPGraphQLGutenberg')) {
             foreach ($attributes as $attribute_name => $attribute) {
                 $type = null;
 
-                switch ($attribute['type']) {
-                    case 'string':
-                        $type = Type::string();
-                        break;
-                    case 'boolean':
-                        $type = Type::boolean();
-                        break;
-                    case 'number':
-                        $type = Type::float();
-                        break;
-                    case 'integer':
-                        $type = Type::int();
-                        break;
-                    case 'array':
-                        $type = self::get_attributes_array_type();
-                        break;
-                    case 'object':
-                        $type = self::get_attributes_object_type();
-                        break;
-                }
+				if (isset($attribute['type'])) {
+					switch ($attribute['type']) {
+						case 'string':
+							$type = Type::string();
+							break;
+						case 'boolean':
+							$type = Type::boolean();
+							break;
+						case 'number':
+							$type = Type::float();
+							break;
+						case 'integer':
+							$type = Type::int();
+							break;
+						case 'array':
+							$type = self::get_attributes_array_type();
+							break;
+						case 'object':
+							$type = self::get_attributes_object_type();
+							break;
+					}
+				}
 
                 if (isset($type)) {
                     if (isset($attribute['default'])) {

--- a/plugin.php
+++ b/plugin.php
@@ -274,28 +274,28 @@ if (!class_exists('WPGraphQLGutenberg')) {
             foreach ($attributes as $attribute_name => $attribute) {
                 $type = null;
 
-				if (isset($attribute['type'])) {
-					switch ($attribute['type']) {
-						case 'string':
-							$type = Type::string();
-							break;
-						case 'boolean':
-							$type = Type::boolean();
-							break;
-						case 'number':
-							$type = Type::float();
-							break;
-						case 'integer':
-							$type = Type::int();
-							break;
-						case 'array':
-							$type = self::get_attributes_array_type();
-							break;
-						case 'object':
-							$type = self::get_attributes_object_type();
-							break;
-					}
-				}
+                if (isset($attribute['type'])) {
+                    switch ($attribute['type']) {
+                        case 'string':
+                            $type = Type::string();
+                            break;
+                        case 'boolean':
+                            $type = Type::boolean();
+                            break;
+                        case 'number':
+                            $type = Type::float();
+                            break;
+                        case 'integer':
+                            $type = Type::int();
+                            break;
+                        case 'array':
+                            $type = self::get_attributes_array_type();
+                            break;
+                        case 'object':
+                            $type = self::get_attributes_object_type();
+                            break;
+                    }
+                }
 
                 if (isset($type)) {
                     if (isset($attribute['default'])) {
@@ -423,9 +423,9 @@ if (!class_exists('WPGraphQLGutenberg')) {
                          *
                          * @param array     $fields           Fields config.
                          * @param string    $type_name        GraphQL type name.
-                         * @param array     $attributes 	  Block type attributes definition.
-                         * @param array     $block_type 	  Block type definition.
-                         * @param object    $type_registry 	  Type registry.
+                         * @param array     $attributes       Block type attributes definition.
+                         * @param array     $block_type       Block type definition.
+                         * @param object    $type_registry       Type registry.
                          */
                         'fields' => apply_filters(
                             'graphql_gutenberg_block_attributes_fields',
@@ -534,7 +534,7 @@ if (!class_exists('WPGraphQLGutenberg')) {
              * Filters the fields for block type.
              *
              * @param array    $fields           Fields config.
-             * @param array     $block_type 	  Block type definition.
+             * @param array     $block_type       Block type definition.
              */
             $fields = apply_filters(
                 'graphql_gutenberg_block_type_fields',
@@ -612,8 +612,8 @@ if (!class_exists('WPGraphQLGutenberg')) {
              * graphql_gutenberg_prepare_block
              * Filters block data before saving to post meta.
              *
-             * @param array    $data             		Data.
-             * @param array     $block_types_per_name 	GraphQL types named array for blocks.
+             * @param array    $data                     Data.
+             * @param array     $block_types_per_name     GraphQL types named array for blocks.
              */
             return apply_filters(
                 'graphql_gutenberg_prepare_block',


### PR DESCRIPTION
solves https://github.com/pristas-peter/wp-graphql-gutenberg/issues/17

Personally I would prefer a solution like (PHP 7.0+)

```php
$attribute['type'] = $attribute['type'] ?? null;
```

or even (PHP 7.4+)

```php
$attribute['type'] ??= null;
```

But I saw in another issue where you went a bit back to support more PHP versions, so I went for this way instead.