### PR TITLE
Release 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Query gutenberg blocks through wp-graphql
 ## Install
 
 -   Requires PHP 7.0+
--   Required wp-graphql 0.8.4+
+-   Requires wp-graphql 0.9.0+
 -   Requires WordPress 5.4+
 
 ### Quick Install

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Query gutenberg blocks through wp-graphql
 ## Install
 
 -   Requires PHP 7.0+
--   Required wp-graphql 0.6.0+
+-   Required wp-graphql 0.8.4+
 -   Requires WordPress 5.4+
 
 ### Quick Install

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
 		]
 	},
 	"require": {
-		"wp-graphql/wp-graphql": ">=0.8.4"
+		"wp-graphql/wp-graphql": ">=0.9.0"
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Description: Enable blocks in WP GraphQL.
  * Author: pristas-peter
  * Author URI:
- * Version: 0.2.1
+ * Version: 0.2.2
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -2,8 +2,11 @@
 
 namespace WPGraphQLGutenberg\Schema;
 
-class Schema {
-	function __construct() {
+class Schema
+{
+	function __construct()
+	{
+		new \WPGraphQLGutenberg\Schema\Types\Scalar\Scalar();
 		new \WPGraphQLGutenberg\Schema\Types\Object\ReusableBlock();
 		new \WPGraphQLGutenberg\Schema\Types\InterfaceType\Block();
 		new \WPGraphQLGutenberg\Schema\Types\InterfaceType\BlockEditorContentNode();

--- a/src/Schema/Types/InterfaceType/BlockEditorContentNode.php
+++ b/src/Schema/Types/InterfaceType/BlockEditorContentNode.php
@@ -12,111 +12,92 @@ class BlockEditorContentNode {
 
 	function __construct() {
 		$fields = [
-			'blocks'            => [
-				'type'        => [
-					'list_of' => [ 'non_null' => 'Block' ],
+			'blocks' => [
+				'type' => [
+					'list_of' => ['non_null' => 'Block']
 				],
-				'description' => __( 'Gutenberg blocks', 'wp-graphql-gutenberg' ),
-				'resolve'     => function ( $model, $args, $context, $info ) {
+				'description' => __('Gutenberg blocks', 'wp-graphql-gutenberg'),
+				'resolve' => function ($model, $args, $context, $info) {
 					$loader = $context->loaders['blocks'];
-					$id     = $model->ID;
-					$loader->add( $id );
+					$id = $model->ID;
+					$loader->add($id);
 
-					return new Deferred(function () use ( &$loader, $id ) {
+					return new Deferred(function () use (&$loader, $id) {
 						$loader->load();
-						return $loader->get( $id );
+						return $loader->get($id);
 					});
-				},
+				}
 			],
-			'blocksJSON'        => [
-				'type'        => 'String',
-				'description' => __( 'Gutenberg blocks as json string', 'wp-graphql-gutenberg' ),
-				'resolve'     => function ( $model, $args, $context, $info ) {
+			'blocksJSON' => [
+				'type' => 'String',
+				'description' => __('Gutenberg blocks as json string', 'wp-graphql-gutenberg'),
+				'resolve' => function ($model, $args, $context, $info) {
 					$loader = $context->loaders['blocks'];
-					$id     = $model->ID;
-					$loader->add( $id );
+					$id = $model->ID;
+					$loader->add($id);
 
-					return new Deferred(function () use ( &$loader, $id ) {
+					return new Deferred(function () use (&$loader, $id) {
 						$loader->load();
-						return json_encode( $loader->get( $id ) );
+						return json_encode($loader->get($id));
 					});
-				},
+				}
 			],
-			'previewBlocks'     => [
-				'type'        => [
-					'list_of' => [ 'non_null' => 'Block' ],
+			'previewBlocks' => [
+				'type' => [
+					'list_of' => ['non_null' => 'Block']
 				],
-				'description' => __( 'Previewed gutenberg blocks', 'wp-graphql-gutenberg' ),
-				'resolve'     => Utils::ensure_capability(
-					function ( $model ) {
-						$id = BlockEditorPreview::get_preview_id( $model->ID, $model->ID );
+				'description' => __('Previewed gutenberg blocks', 'wp-graphql-gutenberg'),
+				'resolve' => Utils::ensure_capability(
+					function ($model) {
+						$id = BlockEditorPreview::get_preview_id($model->ID, $model->ID);
 
-						if ( ! empty( $id ) ) {
-							return PostMeta::get_post( $id )['blocks'];
+						if (!empty($id)) {
+							return PostMeta::get_post($id)['blocks'];
 						}
 
 						return null;
 					},
-					function ( $cap ) {
+					function ($cap) {
 						return $cap->edit_posts;
 					}
-				),
+				)
 			],
 			'previewBlocksJSON' => [
-				'type'        => 'String',
-				'description' => __( 'Previewed Gutenberg blocks as json string', 'wp-graphql-gutenberg' ),
-				'resolve'     => Utils::ensure_capability(
-					function ( $model ) {
-						$id = BlockEditorPreview::get_preview_id( $model->ID, $model->ID );
+				'type' => 'String',
+				'description' => __('Previewed Gutenberg blocks as json string', 'wp-graphql-gutenberg'),
+				'resolve' => Utils::ensure_capability(
+					function ($model) {
+						$id = BlockEditorPreview::get_preview_id($model->ID, $model->ID);
 
-						if ( ! empty( $id ) ) {
-							return json_encode( PostMeta::get_post( $id )['blocks'] );
+						if (!empty($id)) {
+							return json_encode(PostMeta::get_post($id)['blocks']);
 						}
 
 						return null;
 					},
-					function ( $cap ) {
+					function ($cap) {
 						return $cap->edit_posts;
 					}
-				),
-			],
+				)
+			]
 		];
 
-		add_filter('graphql_wp_object_type_config', function ( $config ) use ( $fields ) {
-			if ( in_array( strtolower( $config['name'] ), array_map( 'strtolower', Utils::get_editor_graphql_types() ), true ) ) {
-				$interfaces = $config['interfaces'];
-
-				$config['interfaces'] = function () use ( $interfaces ) {
-					return array_merge( $interfaces(), [ $this->type_registry->get_type( 'BlockEditorContentNode' ) ] );
-				};
-
-				$fields_cb = $config['fields'];
-
-				$config['fields'] = function () use ( $fields_cb, $fields ) {
-					$result = $fields_cb();
-
-					foreach ( $fields as $key => $value ) {
-						$result[ $key ] = $this->type_registry
-							->get_type( 'BlockEditorContentNode' )
-							->getField( $key )->config;
-					}
-
-					return $result;
-				};
-			}
-			return $config;
-		});
-
-		add_action('graphql_register_types', function ( $type_registry ) use ( $fields ) {
+		add_action('graphql_register_types', function ($type_registry) use ($fields) {
 			$this->type_registry = $type_registry;
 
 			register_graphql_interface_type('BlockEditorContentNode', [
-				'description' => __( 'Gutenberg post interface', 'wp-graphql-gutenberg' ),
-				'fields'      => $fields,
-				'resolveType' => function ( $model ) use ( $type_registry ) {
-					return $type_registry->get_type( Utils::get_post_graphql_type( $model, $type_registry ) );
-				},
+				'description' => __('Gutenberg post interface', 'wp-graphql-gutenberg'),
+				'fields' => $fields,
+				'resolveType' => function ($model) use ($type_registry) {
+					return $type_registry->get_type(Utils::get_post_graphql_type($model, $type_registry));
+				}
 			]);
+
+			$types = Utils::get_editor_graphql_types();
+
+			if (count($types)) {
+				register_graphql_interfaces_to_types(['BlockEditorContentNode'], $types);
+			}
 		});
 	}
 }

--- a/src/Schema/Types/Scalar/Scalar.php
+++ b/src/Schema/Types/Scalar/Scalar.php
@@ -2,36 +2,34 @@
 
 namespace WPGraphQLGutenberg\Schema\Types\Scalar;
 
-use GraphQL\Type\Definition\CustomScalarType;
-
-class Scalar {
-	public static function BlockAttributesObject() {
-		static $type = null;
-
-		if ( $type === null ) {
-			$type = register_graphql_scalar([
+class Scalar
+{
+	public function __construct()
+	{
+		add_action('graphql_register_types', function ($type_registry) {
+			register_graphql_scalar([
 				'name'      => 'BlockAttributesObject',
-				'serialize' => function ( $value ) {
-					return json_encode( $value );
+				'serialize' => function ($value) {
+					return json_encode($value);
 				},
 			]);
-		}
 
+			register_graphql_scalar([
+				'name'      => 'BlockAttributesArray',
+				'serialize' => function ($value) {
+					return json_encode($value);
+				},
+			]);
+		});
+	}
+
+	public static function BlockAttributesObject()
+	{
 		return 'BlockAttributesObject';
 	}
 
-	public static function BlockAttributesArray() {
-		static $type = null;
-
-		if ( $type === null ) {
-			$type = register_graphql_scalar([
-				'name'      => 'BlockAttributesArray',
-				'serialize' => function ( $value ) {
-					return json_encode( $value );
-				},
-			]);
-		}
-
+	public static function BlockAttributesArray()
+	{
 		return 'BlockAttributesArray';
 	}
 }

--- a/src/Schema/Types/Scalar/Scalar.php
+++ b/src/Schema/Types/Scalar/Scalar.php
@@ -2,34 +2,28 @@
 
 namespace WPGraphQLGutenberg\Schema\Types\Scalar;
 
-class Scalar
-{
-	public function __construct()
-	{
+class Scalar {
+	public function __construct() {
 		add_action('graphql_register_types', function ($type_registry) {
-			register_graphql_scalar([
-				'name'      => 'BlockAttributesObject',
+			register_graphql_scalar('BlockAttributesObject', [
 				'serialize' => function ($value) {
 					return json_encode($value);
-				},
+				}
 			]);
 
-			register_graphql_scalar([
-				'name'      => 'BlockAttributesArray',
+			register_graphql_scalar('BlockAttributesArray', [
 				'serialize' => function ($value) {
 					return json_encode($value);
-				},
+				}
 			]);
 		});
 	}
 
-	public static function BlockAttributesObject()
-	{
+	public static function BlockAttributesObject() {
 		return 'BlockAttributesObject';
 	}
 
-	public static function BlockAttributesArray()
-	{
+	public static function BlockAttributesArray() {
 		return 'BlockAttributesArray';
 	}
 }


### PR DESCRIPTION
# Release Notes

## Breaking Changes
n/a. Please open an issue if you discover otherwise.

## Bug Fixes

Support for wp-graphql 0.9.0 changes
- Fix register_graphql_scalar call signature updated in upstream
- Change interfaces registration to existing types to use new upstream method
