### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Description: Enable blocks in WP GraphQL.
  * Author: pristas-peter
  * Author URI:
- * Version: 0.3.1
+ * Version: 0.3.2
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */


### PR DESCRIPTION
# Release Notes

## Breaking Changes

## Bug Fixes
- Add a workaround when translations are not working properly when importing @wordpress/blocks directly  #49
- Fix attributes parsing when there is a multiline html source
