### PR TITLE
fix: error type WpBlockAttributesObject does not exists

### DIFF
--- a/src/Schema/Types/Scalar/Scalar.php
+++ b/src/Schema/Types/Scalar/Scalar.php
@@ -4,7 +4,7 @@ namespace WPGraphQLGutenberg\Schema\Types\Scalar;
 
 class Scalar {
 	public function __construct() {
-		add_action('graphql_register_types', function ($type_registry) {
+		add_action('graphql_register_types_late', function ($type_registry) {
 			register_graphql_scalar('BlockAttributesObject', [
 				'serialize' => function ($value) {
 					return json_encode($value);


### PR DESCRIPTION
Today after updating gatsby-source-wordpress-experimental to 5.0.0 I got this error:

<img width="481" alt="Screenshot at Dec 11 13-38-27" src="https://user-images.githubusercontent.com/10927960/101909594-fc23e280-3bbd-11eb-8eb5-dc95d3ca19d3.png">

Also there is related wp-graphql's issue [#1460](https://github.com/wp-graphql/wp-graphql/issues/1460).
Problem solved registering BlockAttributesObject with `graphql_register_types_late` action.
