### PR TITLE
Feature/fix schema config

### DIFF
--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -269,10 +269,10 @@ class BlockTypes {
 					$types = [$type_registry->get_type('Block')];
 
 					foreach ($type_names as $type_name) {
-						$types[] = $config['typeLoader']($type_name);
+						$types[] = $config->getTypeLoader()($type_name);
 					}
 
-					$config['types'] = array_merge($config['types'] ?? [], $types);
+					$config->types = array_merge($config->types ?? [], $types);
 					return $config;
 				},
 				10

--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -269,10 +269,18 @@ class BlockTypes {
 					$types = [$type_registry->get_type('Block')];
 
 					foreach ($type_names as $type_name) {
-						$types[] = $config->getTypeLoader()($type_name);
+						if ( is_array( $config ) ) {
+							$types[] = $config['typeLoader']($type_name);
+						} else {
+							$types[] = $config->getTypeLoader()($type_name);
+						}
 					}
 
-					$config->types = array_merge($config->types ?? [], $types);
+					if ( is_array( $config ) ) {
+						$config['types'] = array_merge($config['types'] ?? [], $types);
+					} else {
+						$config->types = array_merge($config->types ?? [], $types);
+					}
 					return $config;
 				},
 				10


### PR DESCRIPTION
Fix the issue raised as part of this issue - https://github.com/pristas-peter/wp-graphql-gutenberg/issues/72

It appears that GraphQL have changed the value they pass to graphql_schema_config as part of this change https://github.com/wp-graphql/wp-graphql/commit/640ea27fc8a2c5af0726df7744c8d33c52c4d867

This change handles both array and Schema object version, so it is compatible with all versions of wp-graphql.

This change expands on the code suggested by @renrizzolo
