### PR TITLE
Add block attributesJSON field

### DIFF
--- a/src/Schema/Types/InterfaceType/Block.php
+++ b/src/Schema/Types/InterfaceType/Block.php
@@ -81,6 +81,13 @@ class Block {
 					],
 					'order' => [
 						'type' => ['non_null' => 'Int']
+					],
+					'attributesJSON' => [
+						'type' => 'String',
+						'description' => __('Block attributes, JSON encoded', 'wp-graphql-gutenberg'),
+						'resolve' => function ($block, $args, $context, $info) {
+							return json_encode($block->attributes);
+						}
 					]
 				],
 				'resolveType' => function ($block) use ($type_registry) {


### PR DESCRIPTION
Meant to be an analogue to `blocksJSON`, but it can be useful as a fallback if one wants to handle unknown/generic blocks.