### PR TITLE
Wait for all block types to load before updating

### DIFF
--- a/src/Admin/admin.js
+++ b/src/Admin/admin.js
@@ -16,7 +16,9 @@ export const checkIframeAdmin = () => {
 						onComplete();
 						break;
 					case actions.GET_BLOCK_REGISTRY:
-						onComplete( getBlockRegistry() );
+						window.addEventListener('load', function() {
+							onComplete( getBlockRegistry() );
+						});
 						break;
 					default:
 						onError( new Error( __( 'Invalid action', 'wp-graphql-gutenberg' ) ) );


### PR DESCRIPTION
Some block types (e. g. ACF block types) are added during page load. So the return value of window.wp.blocks.getBlockTypes() changes during page load.
Inside the iFrame window when accessing the window.wp.blocks.getBlockTypes() function to get the block types we should wait for the page to load to get all block types.