### PR TITLE
Fix compatibility with wp-graphql-gutenberg-acf

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -148,7 +148,13 @@ class Block implements ArrayAccess {
 
 			$validator = new Validator();
 
-			$result = $validator->schemaValidation((object) $attributes, $schema);
+			if (empty($data['innerHTML'])) {
+				$data['innerHTML'] = '<span data-warning="This block does not contain a render template"></span>';
+			}
+
+			$obj_attrs = json_decode(json_encode($attributes, JSON_FORCE_OBJECT));
+
+			$result = $validator->schemaValidation($obj_attrs, $schema);
 
 			if ($result->isValid()) {
 				return [


### PR DESCRIPTION
Simply casting the $attributes array to an object fails with ACF Pro's
field groups, as there's another nested array. Using JSON decode makes
sure that nested arrays are converted to objects as well

There is also an issue with the HTML loader failing if there's no
innerHTML defined in the block. HTML-less blocks are very useful for
WordPress as a headless CMS with WPGraphQL.

I've added a check for emptyHTML and added an empty span with a `data-attr` warning about the lack of innerHTML.