### PR TITLE
Add a block attribute filter

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -151,15 +151,24 @@ class Block implements ArrayAccess {
 			$result = $validator->schemaValidation((object) $attributes, $schema);
 
 			if ($result->isValid()) {
-				return [
+				 $returnable_attributes = [
 					'attributes' => array_merge(
-						self::source_attributes(HtmlDomParser::str_get_html($data['innerHTML']), $type),
-						$attributes
-					),
-					'type' => $type
-				];
+								self::source_attributes(HtmlDomParser::str_get_html($data['innerHTML']), $type),
+								$attributes
+						),
+						'type' => $type,
+					];
+
+					$filtered_attributes = [];
+					if (has_filter('graphql_gutenberg_block_attribute_value')) {
+						foreach ($returnable_attributes['attributes'] as $key => $value) {
+								$filtered_attributes[$key] = apply_filters('graphql_gutenberg_block_attribute_value', $value);
+						}
+						$returnable_attributes['attributes'] = $filtered_attributes;
+					}
+					return $returnable_attributes;
+				}
 			}
-		}
 
 		return [
 			'attributes' => $attributes,


### PR DESCRIPTION
Adds a new filter called `graphql_gutenberg_block_attribute_value`.

Each attribute value is run through this filter.

Inspiration was taken from here: https://github.com/pristas-peter/wp-graphql-gutenberg/issues/81

This allows user to run modify attributes from their functions.php or theme.

The most common use case will probably be running attribute values through WP Offload S3. Which allows users of that plugin to use WP GraphQL Gutenberg for blocks with images or any other media.

```php
<?php
// In functions.php or plugin.php
function my_theme_modify_graphql_gutenberg_block_attribute($value) { 
  $value = apply_filters('as3cf_filter_post_local_to_provider', $value);
   return $value; 
} 

add_filter('graphql_gutenberg_block_attribute_value', 'my_theme_modify_graphql_gutenberg_block_attributes);
```





