### PR TITLE
[Bugfix] #100 - Plugin breaks with PHP 8

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -148,7 +148,7 @@ class Block implements ArrayAccess {
 
 			$validator = new Validator();
 
-			$result = $validator->schemaValidation((object) $attributes, $schema);
+			$result = $validator->schemaValidation(json_decode(json_encode($attributes)), $schema);
 
 			if ($result->isValid()) {
 				return [


### PR DESCRIPTION
Fixed:
- `$attributes` with nested arrays threw TypeError in PHP 8.0, this was a warning in PHP 7.4.  Fixed by converting nested arrays to objects as well.