### PR TITLE
Rename filter to avoid duplicate

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -128,9 +128,9 @@ class Block implements ArrayAccess {
 		 * Filters the block attributes.
 		 *
 		 * @param array $attributes Block attributes.
-		 * @param array $block      Block object.
+		 * @param array $block_type Block type definition.
 		 */
-		$attributes = apply_filters('graphql_gutenberg_block_attributes_fields', $attributes, $block_type);
+		$attributes = apply_filters('graphql_gutenberg_block_attributes', $attributes, $block_type);
 
 		if ($block_type === null) {
 			return [


### PR DESCRIPTION
Hi @pristas-peter I submitted a filter in https://github.com/pristas-peter/wp-graphql-gutenberg/pull/132 and I didn't realize there was already one with the [same name](https://github.com/pristas-peter/wp-graphql-gutenberg/blob/develop/src/Schema/Types/BlockTypes.php#L165).
In this case I'm just avoiding the duplicate and adjusting the doc block.
I'll be grateful if you can merge it.
Thanks