### PR TITLE
[Bugfix] #100 - Fix parsing empty attributes/HTML

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -157,12 +157,18 @@ class Block implements ArrayAccess {
 
 			$validator = new Validator();
 
-			$result = $validator->schemaValidation(json_decode(json_encode($attributes)), $schema);
+			// Convert $attributes to an object, handle both nested and empty objects.
+			$attrs = empty($attributes)
+				? (object)$attributes
+				: json_decode(json_encode($attributes), false);
+			$result = $validator->schemaValidation($attrs, $schema);
 
 			if ($result->isValid()) {
+				// Avoid empty HTML, which can trigger an error on PHP 8.
+				$html = empty($data['innerHTML']) ? '<!-- -->' : $data['innerHTML'];
 				return [
 					'attributes' => array_merge(
-						self::source_attributes(HtmlDomParser::str_get_html($data['innerHTML']), $type),
+						self::source_attributes(HtmlDomParser::str_get_html($html), $type),
 						$attributes
 					),
 					'type' => $type


### PR DESCRIPTION
Fixes:
- If a block has an empty `$attributes` array (e.g. a normal paragraph),
  then reading attributes saved in the HTML did not work.  This was
  because the conversion of an empty array to an object did not work.
- PHP ≥ 8.0 no longer crashes when `innerHTML` is an empty string.  This
  problem was only visible once the empty array conversion was fixed.