### PR TITLE
[Bugfix] #122 - Fix some core dynamic blocks

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -194,19 +194,19 @@ class Block implements ArrayAccess {
 		$this->attributes = $result['attributes'];
 		$this->attributesType = $result['type'];
 
-		$this->dynamicContent = $this->render_dynamic_content();
+		$this->dynamicContent = $this->render_dynamic_content($data);
 
 	}
 
-	private function render_dynamic_content() {
+	private function render_dynamic_content($data) {
 		$registry = \WP_Block_Type_Registry::get_instance();
 		$server_block_type = $registry->get_registered($this->name);
 
-		if (empty($server_block_type)) {
+		if (empty($server_block_type) || !$server_block_type->is_dynamic()) {
 			return null;
 		}
 
-		return $server_block_type->render($this->attributes);
+		return render_block($data);
 	}
 
 	public function offsetExists($offset) {


### PR DESCRIPTION
Fixed:
- There are some core dynamic blocks which takes three arguments in
  their render function, but the `WP_Block_Type::render()` function
  will only supply two, which means that if a post/page contains any such
  block then the query will crash.  Using the `render_block()` function
  works though, and I suppose that is the 'correct' API to use in this
  case.

  Here are the core blocks affected by this (which will crash the query
  if present on a post/page):
  - `core/comment-author-avatar`
  - `core/comment-author-name`
  - `core/comment-content`
  - `core/comment-date`
  - `core/comment-edit-link`
  - `core/comment-reply-link`
  - `core/comment-template`
  - `core/comment-pagination-next`
  - `core/comment-pagination-numbers`
  - `core/comment-pagination-previous`
  - `core/home-link`
  - `core/navigation-link`
  - `core/navigation-submenu`
  - `core/navigation`
  - `core/page-list`
  - `core/post-author-biography`
  - `core/post-author-name`
  - `core/post-author`
  - `core/post-comments-count`
  - `core/post-comments-form`
  - `core/post-comments-link`
  - `core/post-comments`
  - `core/post-content`
  - `core/post-date`
  - `core/post-excerpt`
  - `core/post-featured-image`
  - `core/post-template`
  - `core/post-terms`
  - `core/post-title`
  - `core/query-pagination-next`
  - `core/query-pagination-numbers`
  - `core/query-pagination-previous`
  - `core/read-more`
  - `core/social-link`
  - `core/table-of-contents`
  - `core/widget-group`