### PR TITLE
Create a union type for types defined as array

### DIFF
--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -73,6 +73,18 @@ class BlockTypes {
 					$type = Scalar::BlockAttributesObject();
 					break;
 			}
+
+			if (is_array($attribute['type'])) {
+				$types = $attribute['type'];
+
+				if(count($types) > 1) {
+					$type = array_map('ucfirst', $types);
+					$type = implode(' | ', $type);
+				} else {
+					$type = reset($types);
+					$type = ucfirst($type);
+				}
+			}
 		} elseif (isset($attribute['source'])) {
 			$type = 'String';
 		}


### PR DESCRIPTION
@pristas-peter for the `templateLock` attribute the type is declared as an array instead of a string. This code creates a union and avoids the warning.

Closes #127 

![CleanShot 2022-03-21 at 16 08 14](https://user-images.githubusercontent.com/11416255/159346071-717e3004-8436-403b-8c21-0e089874e4c2.png)

![CleanShot 2022-03-21 at 16 06 09](https://user-images.githubusercontent.com/11416255/159345769-2ceacc89-85c8-4334-abf3-6413ceaecf3e.png)

Let me know if it makes sense to you. I tried to follow the code standard of the file although it does not match WordPress-Core. Thanks