### PR TITLE
Handles inner blocks on the reusable blocks

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -183,7 +183,19 @@ class Block implements ArrayAccess {
 	}
 
 	public function __construct($data, $post_id, $registry, $order, $parent) {
-		$this->innerBlocks = self::create_blocks($data['innerBlocks'], $post_id, $registry, $this);
+
+		$inner_blocks = $data['innerBlocks'];
+
+		// Handle reusable blocks.
+		if ('core/block' === $data['blockName'] && isset($data['attrs']['ref'])) {
+			$reusable_post = get_post(absint($data['attrs']['ref']));
+
+			if (!empty($reusable_post)) {
+				$inner_blocks = parse_blocks($reusable_post->post_content);
+			}
+		}
+
+		$this->innerBlocks = self::create_blocks($inner_blocks, $post_id, $registry, $this);
 
 		$this->name = $data['blockName'];
 		$this->postId = $post_id;


### PR DESCRIPTION
This PR handles the inner blocks in the reusable blocks. 

The `core/block` block (a.k.a. reusable block) has only a reference to a post in the database that stores the content in the usual way in post content. The added code fills the inner blocks by getting them from the related post. In this way, it is possible to get something more than just the reference.

Before:
![CleanShot 2022-03-30 at 12 15 31](https://user-images.githubusercontent.com/11416255/160869941-6f43ec0c-f1ab-4371-a69c-62360f63e1cc.png)

After:
![CleanShot 2022-03-30 at 12 14 37](https://user-images.githubusercontent.com/11416255/160869846-1c45d0a8-e2b2-4cef-9fa3-6d754b5ee682.png)

@pristas-peter I'll be grateful if you can merge this.