### PR TITLE
Fix value reference warning with PHP 8

### DIFF
--- a/src/Blocks/Registry.php
+++ b/src/Blocks/Registry.php
@@ -22,7 +22,7 @@ class Registry {
 	public static function normalize($block_types) {
 		return array_reduce(
 			$block_types,
-			function (&$arr, $block_type) {
+			function ($arr, $block_type) {
 				$arr[$block_type['name']] = $block_type;
 				return $arr;
 			},


### PR DESCRIPTION
The use of `array_reduce()` on line 23 within the `normalize()` method will cause a "PHP Warning:  WPGraphQLGutenberg\Blocks\Registry::WPGraphQLGutenberg\Blocks\{closure}(): Argument `#1` ($arr) must be passed by reference, value given" warning on PHP 8.0 because the callback is declared to expect the `$arr` parameter to be passed by reference.

Since PHP 8.0, any functions accepting callbacks that are not explicitly specified to accept parameters by reference - such as `array_reduce()` - will now warn if a callback with reference parameters is used, hence the reference in the function declaration is redundant and should be removed.