### PR TITLE
Ensures that block registry is fetched, for loaded pages

### DIFF
--- a/src/Admin/admin.js
+++ b/src/Admin/admin.js
@@ -16,9 +16,13 @@ export const checkIframeAdmin = () => {
 						onComplete();
 						break;
 					case actions.GET_BLOCK_REGISTRY:
-						window.addEventListener('load', function() {
+						if (document.readyState === 'complete') {
 							onComplete( getBlockRegistry() );
-						});
+						} else {
+							window.addEventListener('load', function() {
+								onComplete( getBlockRegistry() );
+							});
+						}
 						break;
 					default:
 						onError( new Error( __( 'Invalid action', 'wp-graphql-gutenberg' ) ) );


### PR DESCRIPTION
Fix for #188

Checks page status before the complete step of the block registry so that it runs immediatly if page is fully loaded. This ensures that the loading does not get stuck forever without errors.