### PR TITLE
[FIX] Support Rich-Text block source

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -57,6 +57,16 @@ class Block implements ArrayAccess {
 			$source = $value['source'] ?? null;
 
 			switch ( $source ) {
+				case 'rich-text':
+					// Most 'html' sources were converted to 'rich-text' in WordPress 6.5.
+					// https://github.com/WordPress/gutenberg/pull/43204
+					$source_node = ! empty( $value['selector'] ) ? $node->findOne( $value['selector'] ) : $node;
+
+					if ( $source_node ) {
+						$result[ $key ] = $source_node->innerhtml;
+					}
+
+					break;
 				case 'html':
 					$source_node = ! empty( $value['selector'] ) ? $node->findOne( $value['selector'] ) : $node;
 


### PR DESCRIPTION
In anticipation of the forthcoming launch of WordPress 6.5, [a significant transition](https://github.com/WordPress/gutenberg/pull/43204) has been made from HTML sources to rich-text formats.

Given the absence of support for the rich-text source in `wp-graphql-gutenberg`, the present Pull Request has been introduced to incorporate this capability.