### PR TITLE
Support `rich-text` Type Attribute Fields

### DIFF
--- a/src/Schema/Types/BlockTypes.php
+++ b/src/Schema/Types/BlockTypes.php
@@ -43,6 +43,7 @@ class BlockTypes {
 		if ( isset( $attribute['type'] ) ) {
 			switch ( $attribute['type'] ) {
 				case 'string':
+				case 'rich-text':
 					$type = 'String';
 					break;
 				case 'boolean':


### PR DESCRIPTION
This fixes missing rich-text fields in block attributes in WP 6.5+