### PR TITLE
fix: :bug: core/html missing content attribute

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -68,6 +68,10 @@ class Block implements ArrayAccess {
 
 					break;
 				case 'html':
+				// core/html source was converted from html to raw which was introduced in WP 6.2
+				// https://github.com/WordPress/gutenberg/pull/27268
+				// https://github.com/WordPress/gutenberg/commit/97eb4a4db1b0f42ca77a1eff335b632584d11226#diff-2ca7aa3d7aa1e1b7045012c90de56f0caf6b1f4a0ac1bd501b0fb3c0c054aa2eR13
+				case 'raw':
 					$source_node = ! empty( $value['selector'] ) ? $node->findOne( $value['selector'] ) : $node;
 
 					if ( $source_node ) {


### PR DESCRIPTION
Since WP 6.2 core/html content attribute was converted from `html` to `raw`. 
This change breaks the behavior of wp-graphql-gutenberg which did not return the `content` attribute anymore.

- [PR responsible  for the change](https://github.com/WordPress/gutenberg/pull/27268)
- [guilty commit](https://github.com/WordPress/gutenberg/commit/97eb4a4db1b0f42ca77a1eff335b632584d11226#diff-2ca7aa3d7aa1e1b7045012c90de56f0caf6b1f4a0ac1bd501b0fb3c0c054aa2eR13)

| WP version |  before the fix | after the fix |
|--- | --- | --- |
| 6.1 | ![wp-6 1-before](https://github.com/user-attachments/assets/b5717dee-b9d3-47e1-9079-96134e3128ca)  |  ![wp-6 1-after](https://github.com/user-attachments/assets/9d7bd79b-7898-4d9b-a4d6-e7de33d90a80) |
| 6.2 | ![wp-6 2-before](https://github.com/user-attachments/assets/00d03651-a069-4a74-93d7-42e6b06acb02) | ![wp-6 2-after](https://github.com/user-attachments/assets/5c1ca1b9-b0c4-48e0-97ca-3e11523d3618)  |




