### PR TITLE
fix: 🐛 add return type declarations for isClientSafe and getCategory methods

### DIFF
--- a/src/Blocks/RegistryNotSourcedException.php
+++ b/src/Blocks/RegistryNotSourcedException.php
@@ -5,11 +5,11 @@ namespace WPGraphQLGutenberg\Blocks;
 use GraphQL\Error\ClientAware;
 
 class RegistryNotSourcedException extends \Exception implements ClientAware {
-	public function isClientSafe() {
+	public function isClientSafe(): bool {
 		return true;
 	}
 
-	public function getCategory() {
+	public function getCategory(): string {
 		return 'gutenberg';
 	}
 }

--- a/src/Server/ServerException.php
+++ b/src/Server/ServerException.php
@@ -1,12 +1,14 @@
 <?php
 namespace WPGraphQLGutenberg\Server;
 
+use GraphQL\Error\ClientAware;
+
 class ServerException extends \Exception implements ClientAware {
-	public function isClientSafe() {
+	public function isClientSafe(): bool {
 		return false;
 	}
 
-	public function getCategory() {
+	public function getCategory(): string {
 		return 'gutenberg-server';
 	}
 }


### PR DESCRIPTION
I don't know exactly why I'm starting to encounter this error now (see below), however this should fix it.

```
{
  "code": "internal_server_error",
  "message": "<p>There has been a critical error on this website.</p><p><a href=\"https://wordpress.org/documentation/article/faq-troubleshooting/\">Learn more about troubleshooting WordPress.</a></p>",
  "data": {
    "status": 500,
    "error": {
      "type": 64,
      "message": "Declaration of WPGraphQLGutenberg\\Blocks\\RegistryNotSourcedException::isClientSafe() must be compatible with GraphQL\\Error\\ClientAware::isClientSafe(): bool",
      "file": "/path/to/wordpress/wp-content/plugins/wp-graphql-gutenberg/src/Blocks/RegistryNotSourcedException.php",
      "line": 8
    }
  },
  "additional_errors": []
}
```

see webonyx/graphql-php `isClientSafe` method https://github.com/webonyx/graphql-php/blob/5dd87a76c486b2e3817c4dd4fe2c1f2ed0e2b0c8/src/Error/Error.php#L194-L197