### PR TITLE
Fix deprecated dynamic property

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -255,19 +255,19 @@ class Block implements ArrayAccess {
 		return render_block( $data );
 	}
 
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		return isset( $this->$offset );
 	}
 
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): mixed {
 		return $this->$offset;
 	}
 
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		$this->$offset = $value;
 	}
 
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 		unset( $this->$offset );
 	}
 }

--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -9,6 +9,20 @@ use Opis\JsonSchema\Validator;
 use voku\helper\HtmlDomParser;
 
 class Block implements ArrayAccess {
+	public array $innerBlocks;
+	public ?string $name;
+	public ?int $postId;
+	public mixed $blockType;
+	public ?string $originalContent;
+	public ?string $saveContent;
+	public ?int $order;
+	public mixed $parent;
+	public mixed $get_parent;
+	public array $attributes;
+	public mixed $attributesType;
+	public mixed $dynamicContent;
+
+
 	public static function create_blocks( $blocks, $post_id, $registry, $parent = null ) {
 		$result = [];
 		$order  = 0;


### PR DESCRIPTION
From PHP 8.2 property that has not been declared raises deprecation warning. This PR adds explicit public properties to the `Block` class to suppress the deprecation warnings

cf. https://wiki.php.net/rfc/deprecate_dynamic_properties

Also it updates the `offsetExists`, `offsetGet`, `offsetSet`, and `offsetUnset` methods to include explicit return type declarations to be compatible with the extends ArrayAccess class.