### PR TITLE
fix: add missing 'type' key for unregistered blocks in parse_attributes

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -149,6 +149,7 @@ class Block implements ArrayAccess {
 		if ( null === $block_type ) {
 			return [
 				'attributes' => $attributes,
+				'type'       => null,
 			];
 		}
 


### PR DESCRIPTION
## Problem

`Block::parse_attributes()` early-returns when the block type is `null` — which happens for any block whose `blockName` isn't in the registry, most commonly **classic / freeform** blocks. That early return omits the `'type'` key that the two other return paths include:

```php
if ( null === $block_type ) {
    return [
        'attributes' => $attributes,
    ];
}
```

`Block::__construct` then reads it unconditionally:

```php
$this->attributesType = $result['type'];
```

So every GraphQL render of a page containing a classic/freeform (or any unregistered) block emits a PHP warning:

```
Undefined array key "type" in .../src/Blocks/Block.php on line 227
```

## Fix

Add `'type' => null` to the early return so all three paths are consistent:

```php
if ( null === $block_type ) {
    return [
        'attributes' => $attributes,
        'type'       => null,
    ];
}
```

This is safe because `attributesType` is only consumed by the resolver for **registered** blocks (`src/Schema/Types/BlockTypes.php`), so `null` for an unregistered block is never read downstream.

`php -l` passes on the changed file.